### PR TITLE
refactored rendering of driver assistance packages in ResultsContainer and Specifications, reduced data replication in JSON

### DIFF
--- a/evstreet/src/components/VehiclePage/Specifications.js
+++ b/evstreet/src/components/VehiclePage/Specifications.js
@@ -90,8 +90,16 @@ function Specifications({ vehicle }) {
     // { level1: {..}, level2: {..}, level3: {..} }
 
   const renderDriverAssistPackages = () => {
-    if (driver_assistance_packages === "none") {
-      return <InlineTypo>{"none"}</InlineTypo>;
+
+    if (driver_assistance_packages === "no") {
+      return (
+        <Grid container>
+          <Grid item sx={{ mt: 2.5 }}>
+            <BoldInlineHeader>Driver Assistance System: </BoldInlineHeader>
+            <InlineTypo>none</InlineTypo>
+          </Grid>
+        </Grid>
+      );
     }
 
     return (

--- a/evstreet/src/components/VehicleSearch/ResultsContainer.js
+++ b/evstreet/src/components/VehicleSearch/ResultsContainer.js
@@ -180,6 +180,13 @@ function ResultsContainer({ filteredVehicleSpecs, lang }) {
     );
   };
 
+  const renderDriverAssistanceValue = () => {
+    if (filteredVehicleSpecs.driver_assistance_packages === "no") {
+      return <ListingSpecs>none</ListingSpecs>
+    }
+    return <ListingSpecs>yes</ListingSpecs>
+  }
+
   const { base_price, label, weight } = filteredVehicleSpecs.trim.standard;
 
   const navigate = useNavigate();
@@ -243,9 +250,7 @@ function ResultsContainer({ filteredVehicleSpecs, lang }) {
 
             <SpecsRows item>
               <BoldTypo>Driver Assistance System: </BoldTypo>
-              <ListingSpecs>
-                {filteredVehicleSpecs.driver_assistance}
-              </ListingSpecs>
+              {renderDriverAssistanceValue()}
             </SpecsRows>
             <SpecsRows item>
               <BoldTypo>Self-Parking: </BoldTypo>

--- a/evstreet/src/config/vehicleData.json
+++ b/evstreet/src/config/vehicleData.json
@@ -10,7 +10,6 @@
     "luxary_vehicle": "yes",
     "drivetrain": "RWD or AWD",
     "self_parking": "yes - Autopilot, Enhanced Autopilot packages",
-    "driver_assistance": "yes",
     "driver_assistance_packages": {
       "level1": {
         "label": "Autopilot",
@@ -99,7 +98,6 @@
     "luxary_vehicle": "yes",
     "drivetrain": "RWD or AWD",
     "self_parking": "yes - Wind, GT-Line trims",
-    "driver_assistance": "yes",
     "driver_assistance_packages": {
       "level1": {
         "label": "Wind (RWD), Wind (e-AWD) trims",
@@ -224,7 +222,6 @@
     "luxary_vehicle": "yes",
     "drivetrain": "AWD",
     "self_parking": "yes - Prestige trim",
-    "driver_assistance": "yes",
     "driver_assistance_packages": {
       "level1": {
         "label": "Premium Plus trim",


### PR DESCRIPTION
In ResultsContainer, refactored to use JSON driver_assistance_packages instead of driver_assistance_system so that data duplication in JSON could be reduced.

In Specifications, refactored output if there in "no" value for driver_assistance_packages.